### PR TITLE
Add librsvg2-bin for .svg figure support

### DIFF
--- a/docker/dockerfile.df
+++ b/docker/dockerfile.df
@@ -19,7 +19,7 @@ RUN apt-get update                                                          \
         texlive-science texlive-pictures                                    \
         texlive-bibtex-extra texlive-lang-english texlive-lang-german       \
         texlive-font-utils texlive-fonts-recommended texlive-fonts-extra    \
-        fontconfig lmodern ghostscript gsfonts cm-super                     \
+        fontconfig lmodern ghostscript gsfonts cm-super librsvg2-bin        \
     #
     # Pandoc
     && wget $PANDOCDEB && dpkg -i pandoc* && rm pandoc*                     \


### PR DESCRIPTION
Will fix `check that rsvg-convert is in path` error when including a figure in .svg format in one of the markdown files