### PR TITLE
Makefile: Set docker working directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ WORKDIR                 = $(CURDIR)
 ## (Defaults to docker. To use pandoc and TeX-Live directly, create an
 ## environment variable `PANDOC` pointing to the location of your
 ## pandoc installation.)
-PANDOC                 ?= docker run --rm -v $(WORKDIR):/pandoc pandoc-thesis pandoc
+PANDOC                 ?= docker run --rm -v $(WORKDIR):/pandoc -w /pandoc pandoc-thesis pandoc
 
 
 ## Source files


### PR DESCRIPTION
The `pandoc-thesis` image has its default CWD set to `/pandoc`. If we change the image to our own LaTeX-image, it will most likely fail to build, because our own image will have another CWD (e.g. `/root`).

Providing `-w /pandoc` lets any image start in this directory, so that the Makefile can build the document.