### PR TITLE
Makefile: use variables for wrkdir, usrid, grpid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,18 @@
 ###############################################################################
 
 
+## Working directory
+## In case this doesn't work, set the path manually (use absolute paths).
+WORKDIR                 = $(shell pwd)
+USRID                   = $(shell id -u)
+GRPID                   = $(shell id -g)
+
+
 ## Pandoc
 ## (Defaults to docker. To use pandoc and TeX-Live directly, create an
 ## environment variable `PANDOC` pointing to the location of your
 ## pandoc installation.)
-PANDOC                 ?= docker run --rm --volume "`pwd`:/data" --workdir /data --user `id -u`:`id -g` pandoc/extra:latest-ubuntu
+PANDOC                 ?= docker run --rm --volume "$(WORKDIR):/data" --workdir /data --user $(USRID):$(GRPID) pandoc/extra:latest-ubuntu
 
 
 ## Source files

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@
 ###############################################################################
 
 
-## Working directory
+## Working directory and User
 ## In case this doesn't work, set the path manually (use absolute paths).
-WORKDIR                 = $(shell pwd)
+WORKDIR                 = .
 USRID                   = $(shell id -u)
 GRPID                   = $(shell id -g)
 


### PR DESCRIPTION
Under Windows, resolving the commands does not seem to work in the Docker call. 

Potential workaround: move commands to separate Makefile variables and set them via shell resolution.

fixes #75