### PR TITLE
Workflow: allow markdown and images in subfolders

### DIFF
--- a/.pandoc/eisvogel.yaml
+++ b/.pandoc/eisvogel.yaml
@@ -3,7 +3,7 @@
 ## (see https://github.com/Wandmalfarbe/pandoc-latex-template)
 
 ## general options
-from: markdown+lists_without_preceding_blankline
+from: markdown+lists_without_preceding_blankline+rebase_relative_paths
 to: pdf
 
 

--- a/.pandoc/simple.yaml
+++ b/.pandoc/simple.yaml
@@ -2,7 +2,7 @@
 ## (see https://pandoc.org/MANUAL.html#defaults-files)
 
 ## general options
-from: markdown+lists_without_preceding_blankline
+from: markdown+lists_without_preceding_blankline+rebase_relative_paths
 to: pdf
 
 


### PR DESCRIPTION
The paths to the images are currently resolved from the root folder. The Markdown file needs to be located directly in the project folder, and the images or the folder containing the images is also located in the project folder: 

```
.
|____thesis.md
|____figs
| |____a.png
|____references.bib
```

would allow `![](figs/a.png)` in `thesis.md`. This would also work using the GitHub preview.

---

However, if you were editing the Markdown file in a sub-folder, the images would still have to be kept at the top level of the project. This means that the GitHub preview no longer works.

---

This PR fixes the issue. If the markdown file is maintained in a sub-folder, then the images can (and must) be located in that sub-folder (or in a sub-folder of this sub-folder) as well. This enables the following scenario: 

```
.
|____fluppie
| |____thesis.md
| |____figs
| | |____c.png
| |____references.bib
```

with `` `![](figs/c.png)` in `thesis.md`. This would also work using the GitHub preview.

---

fixes #86